### PR TITLE
Chore: persistir chaves de DataProtection no Docker (remover warnings de antiforgery)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,12 @@ services:
       - ASPNETCORE_URLS=http://+:8080
       # Importante: usa o nome do serviço 'sql' como host
       - ConnectionStrings__DefaultConnection=Server=sql,1433;Database=CourseEnroll;User Id=sa;Password=${SA_PASSWORD:-Pass@w0rd!};TrustServerCertificate=True;Encrypt=False
+    volumes:
+      - web_keys:/root/.aspnet/DataProtection-Keys
     depends_on:
       sql:
         condition: service_healthy
 
 volumes:
   mssql_data:
+  web_keys:


### PR DESCRIPTION
## Contexto
Após reiniciar o container `web`, novas chaves de DataProtection eram geradas e o cookie antiforgery anterior deixava de ser descriptografado, gerando warnings/exceções no primeiro acesso.

## Mudança
- `docker-compose.yml`:
  - Volume `web_keys:/root/.aspnet/DataProtection-Keys` para persistir chaves no serviço `web`.

## Resultado
- Chaves de DataProtection persistem entre reinícios.
- Sem warnings/exceções de antiforgery após restart.

## Como validar
1. `docker compose up -d --force-recreate web`
2. Limpar cookies do `localhost:5090` e dar **Ctrl+F5**.
3. Acessar `/enroll` e `/enrollments`.
4. `docker compose logs -f web` — não deve registrar `DefaultAntiforgery`/`DataProtection`.

## Risco / Rollback
- Baixo. Rollback: remover a seção `volumes` do serviço `web`.
