### PR TITLE
Feat: Identity (cookie) + proteção de rotas no Blazor

### DIFF
--- a/Areas/Identity/Pages/_Layout.cshtml
+++ b/Areas/Identity/Pages/_Layout.cshtml
@@ -1,0 +1,20 @@
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="utf-8" />
+    <title>Identidade</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="~/bootstrap/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/app.css" />
+</head>
+<body>
+    <div class="container mt-4">
+        @RenderBody()
+    </div>
+
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/Components/Pages/Enrollments.razor
+++ b/Components/Pages/Enrollments.razor
@@ -1,5 +1,6 @@
 @page "/enrollments"
 @rendermode InteractiveServer
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
 @using WebApp.Data
 @using Microsoft.EntityFrameworkCore
 @using MudBlazor

--- a/Components/Pages/Shared/_LoginPartial.cshtml
+++ b/Components/Pages/Shared/_LoginPartial.cshtml
@@ -1,0 +1,28 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@using Microsoft.AspNetCore.Identity
+@inject SignInManager<IdentityUser> SignInManager
+@inject UserManager<IdentityUser> UserManager
+
+<ul class="nav">
+@if (SignInManager.IsSignedIn(User))
+{
+    <li class="nav-item">
+        <span class="nav-link">Olá, @User.Identity?.Name</span>
+    </li>
+    <li class="nav-item">
+        <form class="form-inline" method="post" asp-area="Identity" asp-page="/Account/Logout">
+            <input type="hidden" name="returnUrl" value="/" />
+            <button type="submit" class="nav-link btn btn-link p-0">Logout</button>
+        </form>
+    </li>
+}
+else
+{
+    <li class="nav-item">
+        <a class="nav-link" asp-area="Identity" asp-page="/Account/Register">Register</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" asp-area="Identity" asp-page="/Account/Login">Login</a>
+    </li>
+}
+</ul>

--- a/Components/Routes.razor
+++ b/Components/Routes.razor
@@ -1,6 +1,32 @@
-﻿<Router AppAssembly="typeof(Program).Assembly">
-    <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
-        <FocusOnNavigate RouteData="routeData" Selector="h1" />
-    </Found>
-</Router>
+﻿@using Microsoft.AspNetCore.Components.Authorization
+
+<CascadingAuthenticationState>
+    <Router AppAssembly="typeof(Program).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
+                <NotAuthorized>
+                    <LayoutView Layout="typeof(Layout.MainLayout)">
+                        <div class="m-4">
+                            <h1>Não autorizado</h1>
+                            <p>Você precisa estar autenticado para acessar esta página.</p>
+                            <a href="/Identity/Account/Login">Ir para Login</a>
+                        </div>
+                    </LayoutView>
+                </NotAuthorized>
+                <Authorizing>
+                    <LayoutView Layout="typeof(Layout.MainLayout)">
+                        <p>Verificando credenciais...</p>
+                    </LayoutView>
+                </Authorizing>
+            </AuthorizeRouteView>
+
+            <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        </Found>
+
+        <NotFound>
+            <LayoutView Layout="typeof(Layout.MainLayout)">
+                <p role="alert">Página não encontrada.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -1,8 +1,11 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace WebApp.Data;
 
-public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+public class AppDbContext : IdentityDbContext
 {
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
     public DbSet<Enrollment> Enrollments => Set<Enrollment>();
 }

--- a/Migrations/20250903084607_AddIdentity.Designer.cs
+++ b/Migrations/20250903084607_AddIdentity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WebApp.Data;
 
@@ -11,9 +12,11 @@ using WebApp.Data;
 namespace WebApp.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250903084607_AddIdentity")]
+    partial class AddIdentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250903084607_AddIdentity.cs
+++ b/Migrations/20250903084607_AddIdentity.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIdentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AspNetRoles",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedUserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    EmailConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    PasswordHash = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SecurityStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    TwoFactorEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LockoutEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    AccessFailedCount = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoleClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    RoleId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserLogins",
+                columns: table => new
+                {
+                    LoginProvider = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ProviderKey = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ProviderDisplayName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    RoleId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserTokens",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    LoginProvider = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoleClaims_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "RoleNameIndex",
+                table: "AspNetRoles",
+                column: "NormalizedName",
+                unique: true,
+                filter: "[NormalizedName] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserClaims_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                table: "AspNetUsers",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "UserNameIndex",
+                table: "AspNetUsers",
+                column: "NormalizedUserName",
+                unique: true,
+                filter: "[NormalizedUserName] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AspNetRoleClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserTokens");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,18 +1,37 @@
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using WebApp.Data;
 using MudBlazor.Services;
 using WebApp.Components;
+using WebApp.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Services
+// DbContext
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+// Identity (cookie) + UI padrão (Razor Class Library)
+builder.Services
+    .AddDefaultIdentity<IdentityUser>(options =>
+    {
+        // Ajustes mínimos para dev/demo (refine depois)
+        options.SignIn.RequireConfirmedAccount = false;
+        options.Password.RequireNonAlphanumeric = false;
+        options.Password.RequireUppercase = false;
+        options.Password.RequireDigit = false;
+        options.Password.RequiredLength = 6;
+    })
+    .AddRoles<IdentityRole>()
+    .AddEntityFrameworkStores<AppDbContext>();
+
+// UI do Identity e suportes de página
+builder.Services.AddRazorPages();
+
+// Razor Components (Blazor Server)
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddMudServices();
-
-builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 var app = builder.Build();
 
@@ -25,8 +44,17 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseStaticFiles();
+
+// AuthN/AuthZ
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.UseAntiforgery();
 
+// Páginas do Identity (ex.: /Identity/Account/Login)
+app.MapRazorPages();
+
+// Razor Components
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 

--- a/README.md
+++ b/README.md
@@ -1,91 +1,231 @@
-# Formulário de Inscrição (.NET 8 + Blazor Server + SQL Server)
+# Formulário de Inscrição (.NET 8 + Blazor Server + SQL Server + Identity + Docker)
 
-Projeto de exemplo utilizando **.NET 8**, **Blazor Server** (Razor Components), **MudBlazor** e **Entity Framework Core** (SQL Server).
-Serve como base para um CRUD simples de inscrições com foco em boas práticas e estrutura mínima para entrevistas e portfólio.
+Projeto de exemplo utilizando **.NET 8**, **Blazor Server (Razor Components)**, **MudBlazor**, **Entity Framework Core 9** (SQL Server) e **ASP.NET Core Identity (cookie)**.  
+Serve como base para um CRUD simples de inscrições, com autenticação, **execução via Docker Compose** e boas práticas mínimas para **entrevistas** e **portfólio**.
+
+> **Objetivo didático:** Blazor Server **sem** expor APIs; autenticação por **cookie** (UI do Identity). JWT/OAuth2 pode ser adicionado como etapa posterior.
+
+---
 
 ## 🚀 Stack
-- .NET 8 / ASP.NET Core
-- Blazor Server (Razor Components)
-- MudBlazor (UI)
-- Entity Framework Core 9 (SQL Server)
-- C# 12
+
+- **.NET 8 / ASP.NET Core**
+- **Blazor Server** (Razor Components)
+- **MudBlazor** (UI) – v8.12.0
+- **Entity Framework Core** – v9.0.8 (SQL Server)
+- **ASP.NET Core Identity** (cookie + UI padrão)
+- **Docker Compose** (Web + SQL Server)
+- **C# 12**
+
+---
 
 ## ✨ Funcionalidades
-- Página **/enroll**: formulário para criar inscrições.
-- Página **/enrollments**: listagem das inscrições já cadastradas.
-- Entidade `Enrollment`: `Id`, `FullName`, `Email`, `Course`, `CreatedAt`.
-- Persistência em SQL Server via EF Core.
 
-## 📦 Pré‑requisitos
-- .NET 8 SDK
-- SQL Server (LocalDB, instalação local ou Docker)
-- (Opcional) Docker Desktop para subir o SQL Server rapidamente
+- **/enroll**: Formulário para criar inscrições (validação com DataAnnotations, UX com loading/disable e Snackbar).
+- **/enrollments**: Listagem (MudTable) das últimas inscrições, **protegida** por autenticação.
+- **Autenticação**: Registro/Login via **UI padrão do Identity**.
+- **Persistência**: SQL Server via EF Core (migrations versionadas).
+- **Estabilidade MudBlazor**:
+  - CSS em `<HeadContent>`
+  - **`_content/MudBlazor/MudBlazor.min.js`** adicionado (JSInterop do MudBlazor).
+- **Docker**:
+  - `web`: aplicação ASP.NET
+  - `sql`: SQL Server 2022
+  - **Chaves de Data Protection persistidas** (evita erros de antiforgery após restart).
 
-### Subindo SQL Server via Docker (opcional)
-```bash
-docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=SenhaForte123!" \
-  -p 1433:1433 --name mssql -d mcr.microsoft.com/mssql/server:2022-latest
-```
-
-## ⚙️ Configuração
-Edite `appsettings.json` com sua string de conexão (exemplo):
-```json
-{
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost,1433;Database=CourseEnroll;User ID=sa;Password=SenhaForte123!;TrustServerCertificate=True"
-  }
-}
-```
-
-## 🧱 Migrações / Banco de Dados
-Criar a base e aplicar migrações (na pasta `src/WebApp`):
-```bash
-dotnet ef migrations add InitialCreate
-dotnet ef database update
-```
-> O projeto já inclui migrações; rode apenas o `database update` se não quiser recriá-las.
-
-## ▶️ Executando
-```bash
-dotnet build
-dotnet run
-# Abra: http://localhost:5090
-```
+---
 
 ## 🗂️ Estrutura do projeto (resumo)
+
 ```
 src/WebApp
   ├── Components
-  │   ├── Layout
+  │   ├── App.razor
+  │   ├── Routes.razor
+  │   ├── Layout/
   │   │   ├── MainLayout.razor
   │   │   └── NavMenu.razor
-  │   ├── Pages
-  │   │   ├── Enroll.razor
-  │   │   ├── Enrollments.razor
-  │   │   ├── Home.razor
-  │   │   └── Counter.razor / Weather.razor (exemplos)
-  │   ├── App.razor
-  │   └── Routes.razor
-  ├── Data
-  │   ├── AppDbContext.cs
-  │   └── Enrollment.cs
-  ├── Migrations
+  │   └── Pages/
+  │       ├── Enroll.razor          # formulário (criação)
+  │       └── Enrollments.razor     # listagem (autorizada)
+  ├── Areas/
+  │   └── Identity/
+  │       └── Pages/
+  │           └── _Layout.cshtml    # layout local p/ UI do Identity
+  ├── Pages/
+  │   └── Shared/_LoginPartial.cshtml  # parcial (fallback)
+  ├── Views/
+  │   └── Shared/_LoginPartial.cshtml  # parcial (fallback)
+  ├── Data/
+  │   ├── AppDbContext.cs           # herda de IdentityDbContext
+  │   └── Enrollment.cs             # entidade domínio
+  ├── Migrations/                   # InitialCreate, AddEnrollmentFields, AddIdentity etc.
+  ├── wwwroot/
   ├── Program.cs
-  ├── appsettings*.json
-  └── wwwroot
+  ├── WebApp.csproj
+  ├── docker-compose.yml
+  └── Dockerfile
 ```
 
-## 🔧 Dicas & Notas
-- Se aparecer aviso de **HTTPS redirection** no console em desenvolvimento, é seguro ignorar quando rodando apenas em HTTP.
-- Em cenários com **MudBlazor**, os *providers* comuns em layout são:
+---
+
+## 🔐 Autenticação & Autorização
+
+- **Identity (cookie)** registrado com `AddDefaultIdentity<IdentityUser>()` e UI (Razor Class Library) mapeada via `app.MapRazorPages()`.
+- **Blazor**: `Components/Routes.razor` usa `CascadingAuthenticationState` + `AuthorizeRouteView`.  
+  Páginas podem ser protegidas com:
+  ```razor
+  @attribute [Microsoft.AspNetCore.Authorization.Authorize]
+  ```
+- **URLs úteis**:
+  - Registro: `http://localhost:5090/Identity/Account/Register`
+  - Login: `http://localhost:5090/Identity/Account/Login`
+
+> Para evitar dependência do parcial `_LoginPartial` da RCL, o projeto sobrescreve o layout da área Identity em `Areas/Identity/Pages/_Layout.cshtml`.
+
+---
+
+## 🧱 Banco de Dados & Migrations
+
+- **Banco**: `CourseEnroll`
+- **Entidade**: `Enrollment { Id, FullName, Email, Course?, CreatedAt }`
+- **Migrations** versionadas em `Migrations/`.
+
+### Aplicar migrations **apontando para o SQL do Docker** (porta 14333)
+
+> **Git Bash / Linux / Mac** (variáveis inline):
+
+```bash
+cd src/WebApp
+ConnectionStrings__DefaultConnection='Server=localhost,14333;Database=CourseEnroll;User Id=sa;Password=Pass@w0rd!;TrustServerCertificate=True;Encrypt=False'   dotnet ef database update
+```
+
+> **Observação:** o container `web` já recebe a connection string pelo `docker-compose.yml` usando host `sql` (rede interna do Compose). O comando acima é apenas para aplicar/atualizar o schema **do host** na instância do container `sql`.
+
+---
+
+## 🐳 Docker (Compose)
+
+### `docker-compose.yml` (resumo)
+
+- **sql**: `mcr.microsoft.com/mssql/server:2022-latest`
+  - Porta mapeada: `14333:1433`
+  - Healthcheck com `sqlcmd`
+  - Volume: `mssql_data:/var/opt/mssql`
+- **web**: build do `Dockerfile`, porta `5090:8080`
+  - `ASPNETCORE_ENVIRONMENT=Development`
+  - `ConnectionStrings__DefaultConnection=Server=sql,1433;...`
+  - **Volume** `web_keys:/root/.aspnet/DataProtection-Keys` (💡 evita warnings/exceções de antiforgery após restart)
+
+### Subir tudo
+
+```bash
+cd src/WebApp
+docker compose build
+SA_PASSWORD='Pass@w0rd!' docker compose up -d
+docker compose ps
+```
+
+> **Primeiro uso:** aplique as migrations do host (comando da seção anterior).
+
+### Logs
+
+```bash
+docker compose logs -f web
+docker compose logs -f sql
+```
+
+### Reiniciar somente o web (após mudanças no código)
+
+```bash
+docker compose build web && docker compose up -d web
+```
+
+### Derrubar (⚠️ remove volume do banco)
+
+```bash
+docker compose down -v
+```
+
+---
+
+## ▶️ Executando **sem** Docker (opcional)
+
+```bash
+cd src/WebApp
+dotnet build
+# (opcional) exporte a connection string real via user-secrets ou appsettings.Development.json
+dotnet run
+# http://localhost:5090
+```
+
+> Em **desenvolvimento** o projeto usa HTTP; redirecionamento para HTTPS está habilitado apenas fora de `Development`.
+
+---
+
+## 🧩 Dicas MudBlazor
+
+- Inclua o **CSS** no `<HeadContent>` e o **JS** do MudBlazor **após** `blazor.web.js`:
+  ```razor
+  <HeadContent>
+    <link rel="stylesheet" href="_content/MudBlazor/MudBlazor.min.css" />
+  </HeadContent>
+
+  ...
+  <script src="_framework/blazor.web.js"></script>
+  <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+  ```
+- Providers recomendados no layout:
   ```razor
   <MudThemeProvider />
   <MudPopoverProvider />
   <MudDialogProvider />
   <MudSnackbarProvider />
   ```
-  Certifique-se de que **existe apenas um** `<MudPopoverProvider />` por layout e evite saídas duplicadas para overlays/popovers.
-- Logs de aviso do MudBlazor (analyzers) em **Desenvolvimento** não impedem a execução.
+  **Atenção:** **apenas um** `MudPopoverProvider` por layout para evitar erros de overlay/popover.
+
+---
+
+## 🔄 Fluxo de Git (sugerido)
+
+- **main**: apenas merge da **develop** após homologação.
+- **develop**: integração/testes.
+- **feature branches**: sempre criadas a partir da **develop**.  
+  Ex.: `feat/identity-cookie`, `feat/enroll-validation`, `chore/devops-compose`.
+
+Comandos úteis (primeiro push com upstream):
+```bash
+git switch develop
+git pull --ff-only origin develop
+git switch -c feat/minha-feature
+
+# trabalho...
+git add -A
+git commit -m "feat: descrição curta"
+git push -u origin HEAD
+```
+
+---
+
+## ✅ Checklist de Validação Rápida
+
+1. `docker compose up -d` (com `SA_PASSWORD` definido)  
+2. `dotnet ef database update` apontando para `localhost,14333`  
+3. Acessar `http://localhost:5090/Identity/Account/Register` → criar usuário  
+4. Login e abrir `http://localhost:5090/enrollments` (deve exigir login)  
+5. Criar inscrição em `http://localhost:5090/enroll` e verificar na listagem
+
+---
+
+## 📌 Roadmap (opcional)
+
+- Novos campos em `Enrollment` (VM, validação, migration).
+- **CI/CD** (Azure DevOps): build/test e publish de imagem Docker.
+- **User Secrets** local (quando rodar sem Docker).
+- JWT/OAuth2 (IdentityServer/OpenIddict) **apenas** se necessário para clientes externos.
+
+---
 
 ## 📝 Licença
-MIT. Sinta-se à vontade para usar como base em estudos, entrevistas e POCs.
+
+MIT. Use à vontade em estudos, entrevistas e POCs.

--- a/WebApp.csproj
+++ b/WebApp.csproj
@@ -12,6 +12,11 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
+
+    <!-- Identity (ASP.NET Core 8) -->
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.8" />
+
     <PackageReference Include="MudBlazor" Version="8.12.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Contexto
Habilitar autenticação com **ASP.NET Core Identity (cookie)** e aplicar autorização nas rotas do Blazor Server, seguindo o padrão da DT (Blazor + Identity).

## Escopo
**Alterações principais**
- `Data/AppDbContext.cs`: herda de `IdentityDbContext` e mantém `DbSet<Enrollment>`.
- `WebApp.csproj`: adicionados pacotes `Microsoft.AspNetCore.Identity.EntityFrameworkCore` e `Microsoft.AspNetCore.Identity.UI` (8.0.8).
- `Program.cs`: registrado `AddDefaultIdentity<IdentityUser>()` + `AddEntityFrameworkStores`, `UseAuthentication/UseAuthorization` e `MapRazorPages()`.
- `Areas/Identity/Pages/_Layout.cshtml`: layout local p/ UI do Identity (evita dependência do `_LoginPartial`).
- `Pages/Shared/_LoginPartial.cshtml` e `Views/Shared/_LoginPartial.cshtml`: adicionados (fallback).
- `Components/Routes.razor`: `CascadingAuthenticationState` + `AuthorizeRouteView` (+ views de NotAuthorized/NotFound).
- `Components/Pages/Enrollments.razor`: protegido com `@attribute [Authorize]`.
- `Migrations/*`: migration **AddIdentity** (tabelas do Identity no mesmo DB).

## Resultado
- Páginas do Identity disponíveis:
  - `/Identity/Account/Register`
  - `/Identity/Account/Login`
- Rotas do Blazor respeitam autenticação.
- `/enrollments` exige login.

## Como validar
1. `docker compose build web && docker compose up -d web`
2. Acessar `/Identity/Account/Register` e criar um usuário.
3. Fazer login (`/Identity/Account/Login`) e abrir `/enrollments` — página deve ser acessível.
4. Sair (`Logout`) e tentar `/enrollments` — deve aparecer “Não autorizado”.

## Observações
- Password policy relaxada para DEV (mín. 6 chars).
- Avisos do MudBlazor Analyzer (MUD0002) mantidos para tratar depois.
