### PR TITLE
feat(enroll): add Degree domain and new enrollment fields; update UI

### DIFF
--- a/Components/Pages/Enroll.razor
+++ b/Components/Pages/Enroll.razor
@@ -4,6 +4,7 @@
 @using MudBlazor
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.EntityFrameworkCore
 @inject AppDbContext Db
 @inject ISnackbar Snackbar
 
@@ -34,6 +35,55 @@
       <MudSelectItem Value="@("SQL Server")">SQL Server</MudSelectItem>
     </MudSelect>
 
+    <MudTextField @bind-Value="_vm.MobilePhone"
+                  For="@(() => _vm.MobilePhone)"
+                  Label="Telefone celular (WhatsApp)"
+                  Required="true"
+                  RequiredError="Informe o telefone"
+                  Mask="@(new PatternMask("(00) 00000-0000"))"
+                  Immediate="true" />
+
+    <MudTextField @bind-Value="_vm.Cpf"
+                  For="@(() => _vm.Cpf)"
+                  Label="CPF"
+                  Required="true"
+                  RequiredError="Informe o CPF"
+                  Mask="@(new PatternMask("000.000.000-00"))"
+                  Immediate="true" />
+
+    <MudSelect T="string"
+               @bind-Value="_vm.Gender"
+               For="@(() => _vm.Gender)"
+               Label="Gênero"
+               Required="true"
+               RequiredError="Selecione o gênero">
+      <MudSelectItem Value="@("Masculino")">Masculino</MudSelectItem>
+      <MudSelectItem Value="@("Feminino")">Feminino</MudSelectItem>
+      <MudSelectItem Value="@("Outro")">Outro</MudSelectItem>
+    </MudSelect>
+
+    <MudTextField @bind-Value="_vm.Organization"
+                  For="@(() => _vm.Organization)"
+                  Label="Orgão/Instituição"
+                  Required="true"
+                  RequiredError="Informe o órgão/Instituição"
+                  Immediate="true" />
+
+    <MudSelect T="int"
+               @bind-Value="_vm.DegreeId"
+               For="@(() => _vm.DegreeId)"
+               Label="Titulação"
+               Required="true"
+               RequiredError="Selecione a titulação">
+      @if (_degrees is not null)
+      {
+        @foreach (var d in _degrees)
+        {
+          <MudSelectItem Value="@d.Id">@d.Name</MudSelectItem>
+        }
+      }
+    </MudSelect>
+
     <MudButton ButtonType="ButtonType.Submit"
                Variant="Variant.Filled"
                Class="mt-4"
@@ -50,32 +100,55 @@
 </MudPaper>
 
 @code {
-  // ViewModel da tela
+  // ViewModel da tela (validações alinhadas ao modelo)
   public class EnrollmentInput
   {
     [Required(ErrorMessage = "Informe seu nome completo")]
-    [StringLength(120, ErrorMessage = "Use no máximo {1} caracteres")]
+    [StringLength(200, ErrorMessage = "Use no máximo {1} caracteres")]
     public string? FullName { get; set; }
 
     [Required(ErrorMessage = "Informe um e-mail válido")]
     [EmailAddress(ErrorMessage = "E-mail em formato inválido")]
-    [StringLength(160, ErrorMessage = "Use no máximo {1} caracteres")]
+    [StringLength(256, ErrorMessage = "Use no máximo {1} caracteres")]
     public string? Email { get; set; }
 
-    [StringLength(80, ErrorMessage = "Use no máximo {1} caracteres")]
+    [StringLength(100, ErrorMessage = "Use no máximo {1} caracteres")]
     public string? Course { get; set; }
+
+    [Required(ErrorMessage = "Informe o telefone")]
+    [StringLength(15, MinimumLength = 15, ErrorMessage = "Preencha o telefone completo")]
+    public string? MobilePhone { get; set; }
+
+    [Required(ErrorMessage = "Informe o CPF")]
+    [StringLength(14, MinimumLength = 14, ErrorMessage = "Preencha o CPF completo")]
+    public string? Cpf { get; set; }
+
+    [Required(ErrorMessage = "Selecione o gênero")]
+    [RegularExpression("^(Masculino|Feminino|Outro)$", ErrorMessage = "Selecione uma opção válida")]
+    public string? Gender { get; set; }
+
+    [Required(ErrorMessage = "Informe o órgão/Instituição")]
+    [StringLength(200, ErrorMessage = "Use no máximo {1} caracteres")]
+    public string? Organization { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Selecione a titulação")]
+    public int DegreeId { get; set; }
   }
 
   EnrollmentInput _vm = new();
   EditContext _editContext = default!;
   bool _saving;
   string? _msg;
+  List<Degree> _degrees = new();
 
-  protected override void OnInitialized()
+  protected override async Task OnInitializedAsync()
   {
     _vm = new EnrollmentInput();
     _editContext = new EditContext(_vm);
+    _degrees = await Db.Degrees.OrderBy(d => d.Id).ToListAsync();
   }
+
+  static string OnlyDigits(string value) => new(value.Where(char.IsDigit).ToArray());
 
   async Task Salvar()
   {
@@ -85,12 +158,32 @@
 
     try
     {
+      // Sanitização para gravar só dígitos
+      var phoneDigits = OnlyDigits(_vm.MobilePhone ?? "");
+      var cpfDigits = OnlyDigits(_vm.Cpf ?? "");
+
+      if (phoneDigits.Length != 11)
+      {
+        Snackbar.Add("Telefone inválido. Use 11 dígitos (DDD + número).", Severity.Error);
+        return;
+      }
+      if (cpfDigits.Length != 11)
+      {
+        Snackbar.Add("CPF inválido. Deve conter 11 dígitos.", Severity.Error);
+        return;
+      }
+
       var entity = new Enrollment
       {
-        FullName = _vm.FullName!,
-        Email = _vm.Email!,
-        Course = string.IsNullOrWhiteSpace(_vm.Course) ? null : _vm.Course,
-        CreatedAt = DateTime.UtcNow
+        FullName    = _vm.FullName!,
+        Email       = _vm.Email!,
+        Course      = string.IsNullOrWhiteSpace(_vm.Course) ? null : _vm.Course,
+        MobilePhone = phoneDigits,
+        Cpf         = cpfDigits,
+        Gender      = _vm.Gender!,
+        Organization= _vm.Organization!,
+        DegreeId    = _vm.DegreeId,
+        CreatedAt   = DateTime.UtcNow
       };
 
       Db.Enrollments.Add(entity);

--- a/Components/Pages/Enrollments.razor
+++ b/Components/Pages/Enrollments.razor
@@ -22,14 +22,24 @@
         <MudTh style="width:80px">ID</MudTh>
         <MudTh>Nome</MudTh>
         <MudTh>E-mail</MudTh>
-        <MudTh style="width:160px">Curso</MudTh>
-        <MudTh style="width:200px">Criado em</MudTh>
+        <MudTh style="width:140px">Curso</MudTh>
+        <MudTh style="width:120px">Gênero</MudTh>
+        <MudTh style="width:140px">Titulação</MudTh>
+        <MudTh style="width:140px">Telefone</MudTh>
+        <MudTh style="width:140px">CPF</MudTh>
+        <MudTh style="width:220px">Orgão/Instituição</MudTh>
+        <MudTh style="width:180px">Criado em</MudTh>
       </HeaderContent>
       <RowTemplate>
         <MudTd DataLabel="ID">@context.Id</MudTd>
         <MudTd DataLabel="Nome">@context.FullName</MudTd>
         <MudTd DataLabel="E-mail">@context.Email</MudTd>
         <MudTd DataLabel="Curso">@((string.IsNullOrWhiteSpace(context.Course) ? "-" : context.Course))</MudTd>
+        <MudTd DataLabel="Gênero">@context.Gender</MudTd>
+        <MudTd DataLabel="Titulação">@((context.Degree?.Name) ?? "-")</MudTd>
+        <MudTd DataLabel="Telefone">@FormatPhone(context.MobilePhone)</MudTd>
+        <MudTd DataLabel="CPF">@FormatCpf(context.Cpf)</MudTd>
+        <MudTd DataLabel="Orgão/Instituição">@context.Organization</MudTd>
         <MudTd DataLabel="Criado em">@context.CreatedAt.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</MudTd>
       </RowTemplate>
     </MudTable>
@@ -42,8 +52,27 @@
   protected override async Task OnInitializedAsync()
   {
     _items = await Db.Enrollments
+      .Include(e => e.Degree)
       .OrderByDescending(e => e.Id)
       .Take(20)
       .ToListAsync();
+  }
+
+  static string FormatPhone(string? digits)
+  {
+    if (string.IsNullOrWhiteSpace(digits)) return "-";
+    var d = new string(digits.Where(char.IsDigit).ToArray());
+    if (d.Length == 11)
+      return $"({d[..2]}) {d.Substring(2,5)}-{d.Substring(7,4)}";
+    return digits;
+  }
+
+  static string FormatCpf(string? digits)
+  {
+    if (string.IsNullOrWhiteSpace(digits)) return "-";
+    var d = new string(digits.Where(char.IsDigit).ToArray());
+    if (d.Length == 11)
+      return $"{d[..3]}.{d.Substring(3,3)}.{d.Substring(6,3)}-{d.Substring(9,2)}";
+    return digits;
   }
 }

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -8,4 +8,30 @@ public class AppDbContext : IdentityDbContext
     public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
     public DbSet<Enrollment> Enrollments => Set<Enrollment>();
+    public DbSet<Degree> Degrees => Set<Degree>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        // Degree: apenas constraints; seed ficou na migration
+        builder.Entity<Degree>(e =>
+        {
+            e.Property(d => d.Name).HasMaxLength(50).IsRequired();
+        });
+
+        // Enrollment: limites e FK apontando explicitamente para a navegação 'Degree'
+        builder.Entity<Enrollment>(e =>
+        {
+            e.Property(x => x.MobilePhone).HasMaxLength(11).IsRequired();
+            e.Property(x => x.Cpf).HasMaxLength(11).IsRequired();
+            e.Property(x => x.Gender).HasMaxLength(20).IsRequired();
+            e.Property(x => x.Organization).HasMaxLength(200).IsRequired();
+
+            e.HasOne(x => x.Degree)              // <-- referencia a navegação
+             .WithMany()                         // sem coleção no principal
+             .HasForeignKey(x => x.DegreeId)     // FK concreta
+             .OnDelete(DeleteBehavior.Restrict);
+        });
+    }
 }

--- a/Data/Degree.cs
+++ b/Data/Degree.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WebApp.Data;
+
+public class Degree
+{
+    public int Id { get; set; }
+
+    [Required, MaxLength(50)]
+    public string Name { get; set; } = default!;
+}

--- a/Data/Enrollment.cs
+++ b/Data/Enrollment.cs
@@ -15,5 +15,25 @@ public class Enrollment
     [MaxLength(100)]
     public string? Course { get; set; }
 
+    // Novos campos (armazenar apenas dígitos para MobilePhone e Cpf)
+    [Required, MaxLength(11)]
+    [RegularExpression(@"^\d{11}$", ErrorMessage = "Informe 11 dígitos (DDD + número)")]
+    public string MobilePhone { get; set; } = default!;
+
+    [Required, MaxLength(11)]
+    [RegularExpression(@"^\d{11}$", ErrorMessage = "Informe o CPF com 11 dígitos")]
+    public string Cpf { get; set; } = default!;
+
+    [Required, MaxLength(20)]
+    [RegularExpression("^(Masculino|Feminino|Outro)$", ErrorMessage = "Valores válidos: Masculino, Feminino ou Outro")]
+    public string Gender { get; set; } = default!;
+
+    [Required, MaxLength(200)]
+    public string Organization { get; set; } = default!;
+
+    [Required]
+    public int DegreeId { get; set; }
+    public Degree Degree { get; set; } = default!;
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/Migrations/20250903125849_AddDegreeAndNewEnrollmentFields.Designer.cs
+++ b/Migrations/20250903125849_AddDegreeAndNewEnrollmentFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WebApp.Data;
 
@@ -11,9 +12,11 @@ using WebApp.Data;
 namespace WebApp.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250903125849_AddDegreeAndNewEnrollmentFields")]
+    partial class AddDegreeAndNewEnrollmentFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250903125849_AddDegreeAndNewEnrollmentFields.cs
+++ b/Migrations/20250903125849_AddDegreeAndNewEnrollmentFields.cs
@@ -1,0 +1,236 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+#pragma warning disable CA1814
+
+namespace WebApp.Migrations
+{
+    public partial class AddDegreeAndNewEnrollmentFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // ===== Identity: soltar PKs antes de alterar tamanho das colunas =====
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AspNetUserTokens",
+                table: "AspNetUserTokens");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AspNetUserLogins",
+                table: "AspNetUserLogins");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "AspNetUserTokens",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserTokens",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderKey",
+                table: "AspNetUserLogins",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserLogins",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AspNetUserTokens",
+                table: "AspNetUserTokens",
+                columns: new[] { "UserId", "LoginProvider", "Name" });
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AspNetUserLogins",
+                table: "AspNetUserLogins",
+                columns: new[] { "LoginProvider", "ProviderKey", "UserId" });
+
+            // ===== Novas colunas em Enrollments =====
+            migrationBuilder.AddColumn<string>(
+                name: "Cpf",
+                table: "Enrollments",
+                type: "nvarchar(11)",
+                maxLength: 11,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "DegreeId",
+                table: "Enrollments",
+                type: "int",
+                nullable: false,
+                defaultValue: 1); // GRADUAÇÃO
+
+            migrationBuilder.AddColumn<string>(
+                name: "Gender",
+                table: "Enrollments",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "Outro");
+
+            migrationBuilder.AddColumn<string>(
+                name: "MobilePhone",
+                table: "Enrollments",
+                type: "nvarchar(11)",
+                maxLength: 11,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Organization",
+                table: "Enrollments",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "");
+
+            // ===== Tabela de domínio: Degrees + seed =====
+            migrationBuilder.CreateTable(
+                name: "Degrees",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                              .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Degrees", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Degrees",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { 1, "GRADUAÇÃO" },
+                    { 2, "ESPECIALIZAÇÃO" },
+                    { 3, "DOUTORADO" },
+                    { 4, "PÓS-DOUTORADO" }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Enrollments_DegreeId",
+                table: "Enrollments",
+                column: "DegreeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Enrollments_Degrees_DegreeId",
+                table: "Enrollments",
+                column: "DegreeId",
+                principalTable: "Degrees",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // FK e colunas adicionadas
+            migrationBuilder.DropForeignKey(
+                name: "FK_Enrollments_Degrees_DegreeId",
+                table: "Enrollments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Enrollments_DegreeId",
+                table: "Enrollments");
+
+            migrationBuilder.DropTable(
+                name: "Degrees");
+
+            migrationBuilder.DropColumn(
+                name: "Cpf",
+                table: "Enrollments");
+
+            migrationBuilder.DropColumn(
+                name: "DegreeId",
+                table: "Enrollments");
+
+            migrationBuilder.DropColumn(
+                name: "Gender",
+                table: "Enrollments");
+
+            migrationBuilder.DropColumn(
+                name: "MobilePhone",
+                table: "Enrollments");
+
+            migrationBuilder.DropColumn(
+                name: "Organization",
+                table: "Enrollments");
+
+            // Identity: soltar PKs, reverter tamanho, recriar PKs
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AspNetUserTokens",
+                table: "AspNetUserTokens");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AspNetUserLogins",
+                table: "AspNetUserLogins");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "AspNetUserTokens",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserTokens",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderKey",
+                table: "AspNetUserLogins",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserLogins",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AspNetUserTokens",
+                table: "AspNetUserTokens",
+                columns: new[] { "UserId", "LoginProvider", "Name" });
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AspNetUserLogins",
+                table: "AspNetUserLogins",
+                columns: new[] { "LoginProvider", "ProviderKey", "UserId" });
+        }
+    }
+}


### PR DESCRIPTION
# MR: Novos campos na inscrição + tabela de domínio (Titulação)

## O que foi feito
- Criada entidade **Degree** (tabela de domínio “Titulação”) com seed: GRADUAÇÃO, ESPECIALIZAÇÃO, DOUTORADO, PÓS-DOUTORADO.
- Novos campos em **Enrollment**: `MobilePhone`, `Cpf`, `Gender`, `Organization`, `DegreeId` (com navegação `Degree`).
- **/enroll**: máscaras (telefone/CPF), selects (Gênero/Titulação), sanitização de dígitos e validações alinhadas ao modelo.
- **/enrollments**: colunas adicionadas (Gênero, Titulação, Telefone, CPF, Órgão) com `Include(e => e.Degree)` e formatação amigável.
- `AppDbContext`: configuração explícita da FK para `Degree` e remoção do seed em código (seed ficou na migration).
- Migration **AddDegreeAndNewEnrollmentFields** aplicada.

## Como testar
1. `docker compose build web && docker compose up -d web`
2. Acessar `http://localhost:5090/enroll` e criar uma inscrição de teste.
3. Verificar a listagem em `http://localhost:5090/enrollments`.

## DoD
- [x] Novos campos validados no formulário.
- [x] Persistência no banco (migration aplicada).
- [x] Listagem exibe novas colunas.
- [x] Build ok no Docker, sem novos warnings críticos.

## Risco / Rollback
- Reverter migration: `dotnet ef database update 20250903084607_AddIdentity`
- Reverter código: `git revert <commit_sha>`

## Observações
- Máscaras via `PatternMask` no MudBlazor 8.
- Armazenamento de `MobilePhone` e `Cpf` **somente dígitos** no banco.
